### PR TITLE
Avoid potential memory leak resulting from a page not calling htmlReady()

### DIFF
--- a/angular-seo-server.js
+++ b/angular-seo-server.js
@@ -36,6 +36,9 @@ var renderHtml = function(url, cb) {
             document.addEventListener('__htmlReady__', function() {
                 window.callPhantom();
             }, false);
+            setTimeout(function() {
+                window.callPhantom();
+            }, 10000);
         });
     };
     page.open(url);


### PR DESCRIPTION
Timeout is set to ten seconds.

If page.close() is not called, the PhantomJS process will leak memory. This forces the callback to be invoked after 10 seconds to cover the cases where a script error or a bug in your app results in htmlReady() not being called.
