### PR TITLE
Patch that makes your application readable to crawlers if you  have '!' ...

### DIFF
--- a/angular-seo-server.js
+++ b/angular-seo-server.js
@@ -48,7 +48,7 @@ server.listen(port, function (request, response) {
     var route = parse_qs(request.url)._escaped_fragment_;
     var url = urlPrefix
       + request.url.slice(1, request.url.indexOf('?'))
-      + '#!' + route;
+      + '#!' + decodeURIComponent(route);
     renderHtml(url, function(html) {
         response.statusCode = 200;
         response.write(html);


### PR DESCRIPTION
Hi, I had an issue with FB graph API and other crawlers.
It seems that the crawlers encode the URL if there is a '!' sign in your application URL, which stops your library from working correctly.

I've added decodeURIComponent function at line 51 of the angular-seo-server.js file, which prevents this behavior from happening, and doesn't affect anything else.

I've run your tests, and also did some manual testing with my applicantion and everything seems fine.

I hope that you'll be able to receive this modest contribution
