### PR TITLE
Adding an Express server as a convenient Node wrapper.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 *.sh
+newrelic.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea
 node_modules
 *.sh
-newrelic.js
+newrelic*

--- a/README.md
+++ b/README.md
@@ -113,4 +113,15 @@ if ($args ~ _escaped_fragment_) {
     # Proxy to PhantomJS instance here
 }
 ```
+
+Running using Node and Express
+==============================
+
+Running PhantomJS jobs as a daemon on the server can be very tricky. One solution is to wrap PhantomJS in a regular Node server. The Node server can be run as a daemon using [forever](https://github.com/nodejitsu/forever)
+
+To use Express, first ```npm install``` to retrieve all Node dependencies. Next run something like ```node express-server.js 8888 http://myserver.com/``` or ```forever start express-server.js 8888 http://myserver.com/```
+
+The Express server behaves very similarly to angular-seo-server.js; however, it does not at this time take any options as arguments. All PhantomJS options are hardcoded.
+
 [![githalytics.com alpha](https://cruel-carlota.pagodabox.com/3a55c16a191c4c8222beddcf429c2608 "githalytics.com")](http://githalytics.com/steeve/angular-seo)
+

--- a/angular-seo-server.js
+++ b/angular-seo-server.js
@@ -34,7 +34,9 @@ var renderHtml = function(url, cb) {
     page.onInitialized = function() {
        page.evaluate(function() {
             setTimeout(function() {
+              if (typeof window.callPhantom === 'function') {
                 window.callPhantom();
+              }
             }, 10000);
         });
     };

--- a/express-server.js
+++ b/express-server.js
@@ -1,3 +1,4 @@
+require('newrelic');
 var app = require('express')(),
   port = process.argv[2],
   prefix = process.argv[3],

--- a/express-server.js
+++ b/express-server.js
@@ -29,10 +29,14 @@ var renderHtml = function(url, cb) {
       page.set('onLoadFinished', function() {
         page.get('content', function (content) {
           cb(content);
+          page.release();
           page.close();
+          page = null;
           if (portCounter > 13300) {
             portCounter = 12300;
           }
+
+
         });
 
       });

--- a/express-server.js
+++ b/express-server.js
@@ -61,6 +61,7 @@ app.get('/', function (req, res) {
     },
     url = prefix
       + req.url.slice(1, req.url.indexOf('?'))
+      + '?phantomjs=true'
       + '#!' + decodeURIComponent(route);
 
   renderHtml(url, callback);

--- a/express-server.js
+++ b/express-server.js
@@ -1,0 +1,74 @@
+var app = require('express')(),
+  port = process.argv[2],
+  prefix = process.argv[3],
+  phantom = require('phantom'),
+  noCache = '--disk-cache=no',
+  noSSL = '--ignore-ssl-errors=true',
+  noImages = '--load-images=false',
+  allowRemote = '--local-to-remote-url-access=yes',
+  REGEX = /_escaped_fragment_=([^&]+)/,
+  portCounter = 12300;
+
+var parse_qs = function(s) {
+  var fragment = s.match(REGEX);
+  if (fragment.length > 1) {
+    return fragment[1];
+  }
+
+};
+
+var renderHtml = function(url, cb) {
+  portCounter += 1;
+
+  console.log('PhantomJS query: ' + url + ' using port ' + portCounter + '.');
+
+  phantom.create(noCache, noSSL, noImages, allowRemote, {port: portCounter}, function (ph) {
+    ph.createPage(function (page) {
+
+      page.set('onLoadFinished', function() {
+        page.get('content', function (content) {
+          cb(content);
+          page.close();
+          if (portCounter > 13300) {
+            portCounter = 12300;
+          }
+        });
+
+      });
+//    page.onConsoleMessage = function(msg, lineNum, sourceId) {
+//        console.log('CONSOLE: ' + msg + ' (from line #' + lineNum + ' in "' + sourceId + '")');
+//    };
+      page.set('onInitialized', function() {
+        page.evaluate(function() {
+          setTimeout(function() {
+            window.callPhantom();
+          }, 10000);
+        });
+      });
+
+      page.open(url);
+    })
+  });
+
+
+
+};
+
+app.get('/', function (req, res) {
+  var route = parse_qs(req.url),
+    callback = function (html) {
+      res.send(html);
+    },
+    url = prefix
+      + req.url.slice(1, req.url.indexOf('?'))
+      + '#!' + decodeURIComponent(route);
+
+  renderHtml(url, callback);
+
+});
+
+app.listen(port);
+
+
+console.log('Listening on ' + port + '...');
+console.log('Press Ctrl+C to stop.');

--- a/express-server.js
+++ b/express-server.js
@@ -36,9 +36,14 @@ var renderHtml = function(url, cb) {
         });
 
       });
-//    page.onConsoleMessage = function(msg, lineNum, sourceId) {
-//        console.log('CONSOLE: ' + msg + ' (from line #' + lineNum + ' in "' + sourceId + '")');
-//    };
+
+//      page.onConsoleMessage = function(msg, lineNum, sourceId) {
+//          console.log('CONSOLE: ' + msg + ' (from line #' + lineNum + ' in "' + sourceId + '")');
+//      };
+//      page.onResourceReceived = function(response) {
+//        console.log('Response (#' + response.id + ', stage "' + response.stage + '"): ' + JSON.stringify(response));
+//      };
+
       page.set('onInitialized', function() {
         page.evaluate(function() {
           setTimeout(function() {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "express": "~3.4.4",
-    "phantom": "~0.5.4"
+    "phantom": "~0.5.4",
+    "newrelic": "~1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "angular-seo",
+  "version": "0.0.0",
+  "description": "PhantomJS-based SEO tools for Angular.",
+  "main": "express-server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/deltaepsilon/angular-seo.git"
+  },
+  "keywords": [
+    "angular",
+    "seo",
+    "phantomjs",
+    "phantomjs-node",
+    "node"
+  ],
+  "author": "Christopher Esplin <chris@quiver.is> (http://christopheresplin.com/)",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/deltaepsilon/angular-seo/issues"
+  },
+  "dependencies": {
+    "express": "~3.4.4",
+    "phantom": "~0.5.4"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "express": "~3.4.4",
-    "phantom": "~0.5.4",
+    "phantom": "git://github.com/sgentle/phantomjs-node.git#e029778ec4",
     "newrelic": "~1.2.0"
   }
 }


### PR DESCRIPTION
I could not seem to get PhantomJS to run as a daemon on my production server. This led to some serious thrashing until I discovered https://github.com/sgentle/phantomjs-node

phantomjs-node does some magic to wrap PhantomJS up as regular node.js module that can be required like any other. 

The result is an Express server that can be daemonized easily using forever or pm2.
